### PR TITLE
Fix for new python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools>=61.0"]
 [project]
 name = "runconftools"
 description = "A package which interfaces with the operation repositories that store the configurations used at EHN1"
-version = "1.2.0"
+version = "1.2.1"
 readme = "docs/README.md"
 urls = { Homepage = "https://github.com/DUNE-DAQ/runconftools" }
 requires-python = ">=3.6"

--- a/src/runconftools/ConfPool.py
+++ b/src/runconftools/ConfPool.py
@@ -15,8 +15,8 @@ class ConfPool:
         operation_url: str | None = None,
         base_url: str | None = None,
     ) -> None:
-        self.conf_regex = re.compile("^operation/([^/]+)/(.*)$")
-        self.base_regex = re.compile("^base/(.*)$")
+        self.conf_regex = re.compile(r"^operation/([^/]+)/(.*)$")
+        self.base_regex = re.compile(r"^base/(.*)$")
         self.apparatus = apparatus
         try:
             self.repo = git.Repo(path)
@@ -48,7 +48,7 @@ class ConfPool:
     @staticmethod
     def get_release(default:str = "develop") -> str :
         name = os.environ["SPACK_RELEASE"]
-        regex = re.compile("^([^-]+-v[0-9]+\.[0-9]+\.[0-9]+[^-]*)-[^-]+-[0-9]+$")
+        regex = re.compile(r"^([^-]+-v[0-9]+\.[0-9]+\.[0-9]+[^-]*)-[^-]+-[0-9]+$")
         match = regex.match(name)
         if match :
             return match.group(1)
@@ -103,7 +103,7 @@ class ConfPool:
         return self.__checkout(local_name, ref_name, self.base)
 
     def get_generators(self, base: str) -> list[str]:
-        regex = re.compile("^(?!__init__)(.*)\.py$")
+        regex = re.compile(r"^(?!__init__)(.*)\.py$")
         self.checkout_base(base)
         files = []
         path = self.repo.working_dir + "/functions/generators/" + self.apparatus
@@ -116,7 +116,7 @@ class ConfPool:
         return files
 
     def get_verifiers(self, base: str | None = None) -> list[str]:
-        regex = re.compile("^(?!__init__)(.*)\.py$")
+        regex = re.compile(r"^(?!__init__)(.*)\.py$")
         if base :
             self.checkout_base(base)
             ## otherwise just get the verifiers from the current branch
@@ -147,7 +147,7 @@ class ConfPool:
     def get_confs(
         self,
         release: re.Pattern | None = None,
-        regex: re.Pattern = re.compile(".*"),
+        regex: re.Pattern = re.compile(r".*"),
     ) -> list:
 
         if not release :
@@ -311,7 +311,7 @@ class ConfPool:
 
     def propagate_base(
         self, base: str, release_tag:str|None=None,
-            conf_regex: re.Pattern = re.compile(".*"),
+            conf_regex: re.Pattern = re.compile(r".*"),
             no_push:bool = False
     ) -> bool :    ## we return True if it's ok to proceed with a push because all went well
         if not release_tag:
@@ -347,7 +347,7 @@ class ConfPool:
     def push_configurations(self,
                             base:str,
                             release_tag:str|None = None,
-                            conf_regex: re.Pattern = re.compile(".*") ) :
+                            conf_regex: re.Pattern = re.compile(r".*") ) :
 
         if not release_tag:
             release_tag = base
@@ -405,7 +405,7 @@ class ConfPool:
 
     def remove_configurations(self,
                               release:str|None=None,
-                              conf_regex: re.Pattern = re.compile(".*") ) -> list[str] :
+                              conf_regex: re.Pattern = re.compile(r".*") ) -> list[str] :
 
         versions = self.get_daq_versions()
         


### PR DESCRIPTION
# Description

With the update of the dependencies, some of the regex were giving warning as some charachters were considered escaped. This PR fixes the problem.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

Tested at EHN1.

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

