### PR TITLE
Add timed fetch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools>=61.0"]
 [project]
 name = "runconftools"
 description = "A package which interfaces with the operation repositories that store the configurations used at EHN1"
-version = "1.2.2"
+version = "1.2.3"
 readme = "docs/README.md"
 urls = { Homepage = "https://github.com/DUNE-DAQ/runconftools" }
 requires-python = ">=3.6"

--- a/src/runconftools/ConfPool.py
+++ b/src/runconftools/ConfPool.py
@@ -52,18 +52,18 @@ class ConfPool:
         except git.InvalidGitRepositoryError:
             logging.warning("The repo in %s is empty, cloning from remotes", path)
             self.repo = FetchTimedRepo.clone_from(url=base_url, to_path=path)
-        finally:
-            remotes = [r.name for r in self.repo.remotes]
-            if "base" not in remotes:
-                self.repo.create_remote(name="base", url=base_url)
-            if "operation" not in remotes:
-                self.repo.create_remote(name="operation", url=operation_url)
-            self.base = self.repo.remote("base", fetch_timeout=fetch_timeout)
-            self.operation = self.repo.remote("operation", fetch_timeout=fetch_timeout)
-            logging.info("Repo in %s set with the following remotes:", path)
-            for r in self.repo.remotes:
-                logging.info("%s -> %s", r.name, r.url)
-            sys.path.append(path + "/functions")
+
+        remotes = [r.name for r in self.repo.remotes]
+        if "base" not in remotes:
+            self.repo.create_remote(name="base", url=base_url)
+        if "operation" not in remotes:
+            self.repo.create_remote(name="operation", url=operation_url)
+        self.base = self.repo.remote("base", fetch_timeout=fetch_timeout)
+        self.operation = self.repo.remote("operation", fetch_timeout=fetch_timeout)
+        logging.info("Repo in %s set with the following remotes:", path)
+        for r in self.repo.remotes:
+            logging.info("%s -> %s", r.name, r.url)
+        sys.path.append(path + "/functions")
 
         ## this protection is necessary in case local base branch exist, example develop which is created by default
         ## In principle this could be done on any branch that does not respect the branch structure

--- a/src/runconftools/ConfPool.py
+++ b/src/runconftools/ConfPool.py
@@ -9,18 +9,17 @@ import git
 
 class FetchTimedRemote(git.Remote):
     '''
-    HW: Wrapper around remote, times fetch calls and skips if called again in a FETCH_TIMEOUT second window
+    HW: Wrapper around remote, times fetch calls and skips if called again in a fetch_time second window [defaults to 30s]
     '''
-    FETCH_TIMEOUT = 30  # seconds
-
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, fetch_timeout: float = 30.0, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fetch_timeout = fetch_timeout
         self._fetch_time: float | None = None
 
     def fetch(self, *args, **kwargs):
         current_fetch_time = perf_counter()
-        if self._fetch_time is not None and current_fetch_time - self._fetch_time < self.FETCH_TIMEOUT:
-            logging.debug(f"Fetch called again within {self.FETCH_TIMEOUT} seconds, skipping fetch")
+        if self._fetch_time is not None and current_fetch_time - self._fetch_time < self.fetch_timeout:
+            logging.debug(f"Fetch called again within {self.fetch_timeout} seconds, skipping fetch")
             return
 
         self._fetch_time = current_fetch_time
@@ -28,8 +27,8 @@ class FetchTimedRemote(git.Remote):
 
 
 class FetchTimedRepo(git.Repo):
-    def remote(self, name: str = "origin")->"FetchTimedRemote":
-        r = FetchTimedRemote(self, name)
+    def remote(self, name: str = "origin", fetch_timeout: float = 30.0)->"FetchTimedRemote":
+        r = FetchTimedRemote(self, name, fetch_timeout=fetch_timeout)
         if not r.exists():
             raise ValueError("Remote named '%s' didn't exist" % name)
         return r
@@ -42,10 +41,12 @@ class ConfPool:
         apparatus: str = "np02",
         operation_url: str | None = None,
         base_url: str | None = None,
+        fetch_timeout: float = 30.0
     ) -> None:
         self.conf_regex = re.compile(r"^operation/([^/]+)/(.*)$")
         self.base_regex = re.compile(r"^base/(.*)$")
         self.apparatus = apparatus
+        
         try:
             self.repo = FetchTimedRepo(path)
         except git.InvalidGitRepositoryError:
@@ -57,8 +58,8 @@ class ConfPool:
                 self.repo.create_remote(name="base", url=base_url)
             if "operation" not in remotes:
                 self.repo.create_remote(name="operation", url=operation_url)
-            self.base = self.repo.remote("base")
-            self.operation = self.repo.remote("operation")
+            self.base = self.repo.remote("base", fetch_timeout=fetch_timeout)
+            self.operation = self.repo.remote("operation", fetch_timeout=fetch_timeout)
             logging.info("Repo in %s set with the following remotes:", path)
             for r in self.repo.remotes:
                 logging.info("%s -> %s", r.name, r.url)

--- a/src/runconftools/ConfPool.py
+++ b/src/runconftools/ConfPool.py
@@ -20,7 +20,7 @@ class FetchTimedRemote(git.Remote):
     def fetch(self, *args, **kwargs):
         current_fetch_time = perf_counter()
         if self._fetch_time is not None and current_fetch_time - self._fetch_time < self.FETCH_TIMEOUT:
-            logging.info(f"Fetch called again within {self.FETCH_TIMEOUT} seconds, skipping fetch")
+            logging.debug(f"Fetch called again within {self.FETCH_TIMEOUT} seconds, skipping fetch")
             return
 
         self._fetch_time = current_fetch_time

--- a/src/runconftools/ConfPool.py
+++ b/src/runconftools/ConfPool.py
@@ -3,8 +3,36 @@ import logging
 import os
 import re
 import sys
+from time import perf_counter
 
 import git
+
+class FetchTimedRemote(git.Remote):
+    '''
+    HW: Wrapper around remote, times fetch calls and skips if called again in a FETCH_TIMEOUT second window
+    '''
+    FETCH_TIMEOUT = 30  # seconds
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._fetch_time: float | None = None
+
+    def fetch(self, *args, **kwargs):
+        current_fetch_time = perf_counter()
+        if self._fetch_time is not None and current_fetch_time - self._fetch_time < self.FETCH_TIMEOUT:
+            logging.info(f"Fetch called again within {self.FETCH_TIMEOUT} seconds, skipping fetch")
+            return
+
+        self._fetch_time = current_fetch_time
+        super().fetch(*args, **kwargs)
+
+
+class FetchTimedRepo(git.Repo):
+    def remote(self, name: str = "origin")->"FetchTimedRemote":
+        r = FetchTimedRemote(self, name)
+        if not r.exists():
+            raise ValueError("Remote named '%s' didn't exist" % name)
+        return r
 
 
 class ConfPool:
@@ -19,10 +47,10 @@ class ConfPool:
         self.base_regex = re.compile(r"^base/(.*)$")
         self.apparatus = apparatus
         try:
-            self.repo = git.Repo(path)
+            self.repo = FetchTimedRepo(path)
         except git.InvalidGitRepositoryError:
             logging.warning("The repo in %s is empty, cloning from remotes", path)
-            self.repo = git.Repo.clone_from(url=base_url, to_path=path)
+            self.repo = FetchTimedRepo.clone_from(url=base_url, to_path=path)
         finally:
             remotes = [r.name for r in self.repo.remotes]
             if "base" not in remotes:
@@ -53,7 +81,7 @@ class ConfPool:
         if match :
             return match.group(1)
         return default
-                
+
     def get_base_branches(self) -> list[str]:
         self.base.fetch()
         branches = [r.name for r in self.base.refs]
@@ -88,7 +116,7 @@ class ConfPool:
         remote.pull(f"{ref_name}:{local_name}")
         self.setup_conf_path()
         return head
-            
+
 
     def checkout_base(self, base: str) -> git.refs.head.Head:
         bases = self.get_base_branches()
@@ -120,7 +148,7 @@ class ConfPool:
         if base :
             self.checkout_base(base)
             ## otherwise just get the verifiers from the current branch
-            
+
         files = []
         path = self.repo.working_dir + "/functions/verifiers"
         if os.path.isdir(path):
@@ -152,7 +180,7 @@ class ConfPool:
 
         if not release :
             release = re.compile("^"+self.get_release()+"$")
-            
+
         self.operation.fetch()
         branches = [r.name for r in self.operation.refs]
         confs = []
@@ -176,8 +204,8 @@ class ConfPool:
     ) -> git.refs.head.Head:
 
         if not release :
-            release =  self.get_release()
-            
+            release = self.get_release()
+
         confs = self.get_confs(release=re.compile(release))
         if conf not in confs:
             logging.error("%s not in the configurations for %s", conf, release)
@@ -187,7 +215,7 @@ class ConfPool:
         return self.__checkout(ref_name, ref_name, self.operation)
 
     def remove_unused_sessions(self) -> list[str] :
-                
+
         # file to be saved
         base_module_name = "common."+self.apparatus + ".config_base"
         base_module = None
@@ -215,11 +243,11 @@ class ConfPool:
             for f in to_be_removed :
                 self.repo.git.rm("-f", f)
             files = to_be_removed
-        
-        return files
-        
 
-    
+        return files
+
+
+
     def generate_conf(
             self, base: str, generator: str,
             release_tag: str | None = None, log_message: str | None = None, no_push:bool = False
@@ -230,7 +258,7 @@ class ConfPool:
         confs = self.get_confs(release=re.compile(f"^{release_tag}$"))
 
         logging.debug("Available confs: " + ", ".join(confs))
-        
+
         ref_name = release_tag + "/" + generator
 
         # prepare the branch
@@ -281,8 +309,8 @@ class ConfPool:
             return res
 
         self.remove_unused_sessions()
-        
-        ## verfication which might produce files 
+
+        ## verfication which might produce files
         logging.info("---- Verification ----")
         very = self.verify()
 
@@ -291,8 +319,8 @@ class ConfPool:
         ## stop the process if veryfication failed
         if not very :
             logging.error(f"Verfication failed for {generator}")
-            return None 
-        
+            return None
+
         ## validate
         if hasattr(module, "validate"):
             valctor = getattr(module, "validate")
@@ -302,11 +330,11 @@ class ConfPool:
                 return res
         else:
             logging.warning(f"{generator} has no validation")
-        
+
         # push the branch
         if not no_push :
             self.operation.push(f"{ref_name}")
-            
+
         return res
 
     def propagate_base(
@@ -341,7 +369,7 @@ class ConfPool:
                 except Exception as e:
                     logging.error(f"Exception raised when trying to generate {g}: {e}")
                     ret = False
-                   
+
         return ret
 
     def push_configurations(self,
@@ -351,7 +379,7 @@ class ConfPool:
 
         if not release_tag:
             release_tag = base
-            
+
         base_head = self.checkout_base(base)
         if not base_head:
             return
@@ -380,8 +408,8 @@ class ConfPool:
 
         logging.info("Verification successful!")
         return True
-            
-        
+
+
     def commit(self, message: str):
         # find the changes
         files = self.repo.git.diff(None, name_only=True)
@@ -392,7 +420,7 @@ class ConfPool:
         logging.debug("Files that changed: " + ", ".join(file_list))
         for f in file_list:
             self.repo.git.add(f)
-            
+
         ## add possible additional file in case they are useful for backup
         files = self.repo.untracked_files
         for f in files :
@@ -408,7 +436,7 @@ class ConfPool:
                               conf_regex: re.Pattern = re.compile(r".*") ) -> list[str] :
 
         versions = self.get_daq_versions()
-        
+
         if not release:
             logging.warning("No release specified, nothing is removed")
             return []


### PR DESCRIPTION
# Description
Add 30s timer to git fetches to prevent unnecessary remote calls.

See issue #19  for details

* Add 2 classes to override `git.Repo` and `git.Repo.remote` which neatly embeds the timer across all fetch calls


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

