### PR TITLE
Fix of the regex

### DIFF
--- a/src/runconftools/ConfPool.py
+++ b/src/runconftools/ConfPool.py
@@ -73,7 +73,7 @@ class ConfPool:
                 default_branch = line.split("refs/heads/")[1].split("\t")[0]
                                 
         logging.info(f"Branch {default_branch} will be ignored in operation")
-        self.default_regex = re.compile(f"^(?:[^\/]+\/)?{default_branch}$")  ## we only check that it ends with this name
+        self.default_regex = re.compile(rf"^(?:[^/]+/)?{default_branch}$")  ## we only check that it ends with this name
         
 
         ## this protection is necessary in case local base branch exist, example develop which is created by default


### PR DESCRIPTION
# Description

Michal reported that running with one of the nightly we got a warning:

```
((dbt) ) [mrigan@np04-srv-016 NFD_DEV_260610_A9]$ cpm-update -b develop -r develop -a np04 np04
/nfs/home/mrigan/dune-daq/NFD_DEV_260610_A9/.venv/lib/python3.12/site-packages/runconftools/ConfPool.py:76: SyntaxWarning: invalid escape sequence '\/'
  self.default_regex = re.compile(f"^(?:[^\/]+\/)?{default_branch}$")  ## we only check that it ends with this name
```

This should remove the warning. 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Running any of the cpm script will show if the warning is present or not.
## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

